### PR TITLE
Fix handling of assetsPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ npx dendron-publish-drawio
 cd .next/
 npm run export
 ```
+
+Note that if you customise Dendron's [`site:assetsPrefix`](https://wiki.dendron.so/notes/f2ed8639-a604-4a9d-b76c-41e205fb8713/#assetsprefix) option (or set it via `--overrides=assetsPrefix=...`) you'll need to set the `DENDRON_ASSETS_PREFIX` environment variable to the same value when running `dendron-publish-drawio`:
+
+```console
+export DENDRON_ASSETS_PREFIX=/etc npx dendron-publish-drawio
+```

--- a/bin/dendron-publish-drawio.js
+++ b/bin/dendron-publish-drawio.js
@@ -19,6 +19,9 @@ const FILE_ENCODING = "utf8";
 // Root of the .next directory.
 const WORKSPACE = process.cwd();
 
+// Dendron assetsPrefix value.
+const ASSETS_PREFIX = process.env.DENDRON_ASSETS_PREFIX || "";
+
 // Set of (filename, pageIndex, outputAssetName) tuples that need exporting to
 // SVG, as referenced in notes.
 const embeddedDiagrams = new Set();
@@ -39,7 +42,7 @@ async function main() {
     let numRefs = new Counter();
     const noteFileGenerator = getPublishedNoteFiles(templatePath);
     for await (const notePath of noteFileGenerator) {
-      const diagramSrcGenerator = rewriteDrawioDiagramSrcs(notePath, numFiles);
+      const diagramSrcGenerator = rewriteDrawioDiagramSrcs(notePath, ASSETS_PREFIX, numFiles);
       for await (const diagramRef of diagramSrcGenerator) {
         numRefs.count();
         embeddedDiagrams.add(diagramRef);

--- a/lib/dendron-note.js
+++ b/lib/dendron-note.js
@@ -5,12 +5,15 @@ const FILE_ENCODING = "utf8";
 // Matches src="some/file.drawio" and src="some/file.drawio#42"
 const DIAGRAM_SRC_RE = /src="(?<filename>[a-zA-Z0-9\/\.]+\.drawio)(#(?<pageIndex>[0-9]+))?"/g;
 
-async function* rewriteDrawioDiagramSrcs(notePath, numFiles) {
+async function* rewriteDrawioDiagramSrcs(notePath, assetsPrefix, numFiles) {
   let contents = await fs.readFile(notePath, FILE_ENCODING);
   let numMatches = 0;
   for (const match of contents.matchAll(DIAGRAM_SRC_RE)) {
     numMatches++;
-    yield [match.groups.filename, parseInt(match.groups.pageIndex, 10) || 0];
+    const filename = assetsPrefix.length > 0 ?
+      match.groups.filename.substring(assetsPrefix.length + 1) :
+      match.groups.filename;
+    yield [filename, parseInt(match.groups.pageIndex, 10) || 0];
   }
 
   if (numMatches > 0) {

--- a/lib/dendron-note.test.js
+++ b/lib/dendron-note.test.js
@@ -11,7 +11,7 @@ describe("rewriteDrawioDiagramSrcs", () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-  })
+  });
 
   it("rewrites HTML files with matches", async () => {
     readFileMock.mockImplementation(async () => {
@@ -21,7 +21,25 @@ describe("rewriteDrawioDiagramSrcs", () => {
 
     const counter = new Counter();
     const diagramSrcGenerator = rewriteDrawioDiagramSrcs(
-      "/dendron/.next/data/notes/l.md", counter);
+      "/dendron/.next/data/notes/l.md", "", counter);
+    const diagramSrcs = [];
+    for await (const diagramSrc of diagramSrcGenerator) {
+      diagramSrcs.push(diagramSrc);
+    }
+
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores assetsPrefix in matches", async () => {
+    readFileMock.mockImplementation(async () => {
+      return `<h1>My diagram</h1>
+<img src="/etc/assets/diagrams/my.diagram.drawio#1" alt="My diagram">`;
+    });
+
+    const counter = new Counter();
+    const diagramSrcGenerator = rewriteDrawioDiagramSrcs(
+      "/dendron/.next/data/notes/l.md", "/etc", counter);
     const diagramSrcs = [];
     for await (const diagramSrc of diagramSrcGenerator) {
       diagramSrcs.push(diagramSrc);
@@ -39,7 +57,7 @@ describe("rewriteDrawioDiagramSrcs", () => {
 
     const counter = new Counter();
     const diagramSrcGenerator = rewriteDrawioDiagramSrcs(
-      "/dendron/.next/data/notes/l.md", counter);
+      "/dendron/.next/data/notes/l.md", "", counter);
     const diagramSrcs = [];
     for await (const diagramSrc of diagramSrcGenerator) {
       diagramSrcs.push(diagramSrc);
@@ -59,7 +77,7 @@ describe("rewriteDrawioDiagramSrcs", () => {
 
     const counter = new Counter();
     const diagramSrcGenerator = rewriteDrawioDiagramSrcs(
-      "/dendron/.next/data/notes/l.md", counter);
+      "/dendron/.next/data/notes/l.md", "", counter);
     const diagramSrcs = [];
     for await (const diagramSrc of diagramSrcGenerator) {
       diagramSrcs.push(diagramSrc);
@@ -76,7 +94,7 @@ describe("rewriteDrawioDiagramSrcs", () => {
 
     const counter = new Counter();
     const diagramSrcGenerator = rewriteDrawioDiagramSrcs(
-      "/dendron/.next/data/notes/l.md", counter);
+      "/dendron/.next/data/notes/l.md", "", counter);
     const diagramSrcs = [];
     for await (const diagramSrc of diagramSrcGenerator) {
       diagramSrcs.push(diagramSrc);


### PR DESCRIPTION
It seems I totally misunderstood assetsPrefix: it allows relocation of a published site from the root of a site to a subdirectory.

Set the environment variable DENDRON_ASSETS_PREFIX to the value of either `--overrides=assetsPrefix=/blah` or `site:assetsPrefix` in `dendron.yml`.

Fixes #2