### PR TITLE
Only read diagram files once

### DIFF
--- a/lib/diagram-set.js
+++ b/lib/diagram-set.js
@@ -1,0 +1,21 @@
+class DiagramSet {
+  constructor() {
+    this.diagrams = {};
+  }
+
+  add(filename, pageIndex) {
+    if (!this.diagrams.hasOwnProperty(filename)) {
+      this.diagrams[filename] = new Set();
+    }
+
+    this.diagrams[filename].add(pageIndex);
+  }
+
+  *[Symbol.iterator]() {
+    for (const entry of Object.entries(this.diagrams)) {
+      yield entry;
+    }
+  }
+}
+
+module.exports = DiagramSet;

--- a/lib/diagram-set.test.js
+++ b/lib/diagram-set.test.js
@@ -1,0 +1,20 @@
+const DiagramSet = require("./diagram-set");
+
+describe("DiagramSet", () => {
+  it("stores filename and pageIndex pairs and iterates by filename", () => {
+    const diagramSet = new DiagramSet();
+    diagramSet.add("test1.drawio", 1);
+    diagramSet.add("test1.drawio", 2);
+    diagramSet.add("test2.drawio", 3);
+
+    const diagrams = {};
+    for (const [filename, pageIndices] of diagramSet) {
+      diagrams[filename] = pageIndices;
+    }
+
+    expect(diagrams).toEqual({
+      "test1.drawio": new Set([1, 2]),
+      "test2.drawio": new Set([3]),
+    });
+  });
+});


### PR DESCRIPTION
We used to re-read the diagram file's contents once per page index. This should offer a very minimal performance improvement...